### PR TITLE
Merge develop into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,9 @@ jobs:
         run: poetry run pre-commit run --show-diff-on-failure --all-files
 
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -28,13 +28,9 @@
     "supply chain optimization"
   ],
   "access_right": "open",
-  "license": {
-    "id": "MIT"
-  },
+  "license": "MIT",
   "upload_type": "software",
   "publication_date": "2025-01-17",
-  "version": "0.1.0",
-  "language": "eng",
   "subjects": [
     {
       "term": "Computer Science",
@@ -65,7 +61,7 @@
     },
     {
       "relation": "isIdenticalTo",
-      "identifier": "https://github.com/DiogoRibeiro7/min-ratio-cycle",
+      "identifier": "https://github.com/DiogoRibeiro7/min_ratio_cycle",
       "resource_type": "software"
     },
     {
@@ -81,8 +77,6 @@
     "Harris, C. R., et al. (2020). Array programming with NumPy. Nature, 585(7825), 357-362. https://doi.org/10.1038/s41586-020-2649-2"
   ],
   "notes": "This software implements state-of-the-art algorithms for the minimum cost-to-time ratio cycle problem, providing both exact and approximate solutions with comprehensive validation and performance analytics. The library is designed for research and industrial applications in optimization, finance, and operations research.",
-  "method": "The software implements Lawler's parametric search algorithm combined with vectorized Bellman-Ford negative cycle detection. For integer weights, exact solutions are computed using Stern-Brocot tree search to eliminate floating-point precision errors.",
-  "funding": [],
   "grants": [],
   "thesis_supervisors": [],
   "thesis_university": "",
@@ -105,43 +99,5 @@
     {
       "identifier": "zenodo"
     }
-  ],
-  "custom": {
-    "programming_language": [
-      {
-        "name": "Python",
-        "version": ">=3.10"
-      }
-    ],
-    "software_dependencies": [
-      "numpy>=1.25",
-      "matplotlib>=3.7",
-      "networkx>=3.2",
-      "psutil>=7.0"
-    ],
-    "operating_systems": [
-      "Linux",
-      "Windows",
-      "macOS"
-    ],
-    "architectures": [
-      "x86_64",
-      "ARM64",
-      "Apple Silicon"
-    ],
-    "development_status": "Stable",
-    "intended_audience": [
-      "Researchers",
-      "Data Scientists",
-      "Operations Research Practitioners",
-      "Financial Analysts",
-      "Network Engineers"
-    ],
-    "software_type": "Library",
-    "repository_stats": {
-      "lines_of_code": "~5000",
-      "test_coverage": ">95%",
-      "documentation_coverage": "100%"
-    }
-  }
+  ]
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,18 +4,21 @@ message: >-
 
 title: "min-ratio-cycle: Fast minimum cost-to-time ratio cycle detection"
 abstract: >-
-  A high-performance Python library for finding minimum cost-to-time ratio 
-  cycles in directed graphs. Features NumPy-accelerated algorithms with 
-  exact Stern-Brocot search for integer inputs, comprehensive validation, 
-  performance analytics, and visualization tools. Implements Lawler's 
+  A high-performance Python library for finding minimum cost-to-time ratio
+  cycles in directed graphs. Features NumPy-accelerated algorithms with
+  exact Stern-Brocot search for integer inputs, comprehensive validation,
+  performance analytics, and visualization tools. Implements Lawler's
   parametric search with vectorized Bellman-Ford negative cycle detection.
 
 version: 0.1.0
 date-released: "2025-01-17"
 license: MIT
 type: software
-repository-code: "https://github.com/DiogoRibeiro7/min-ratio-cycle"
+repository-code: "https://github.com/DiogoRibeiro7/min_ratio_cycle"
 url: "https://min-ratio-cycle.readthedocs.io/"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.17067890"
 
 authors:
   - family-names: Ribeiro
@@ -52,8 +55,9 @@ preferred-citation:
   version: 0.1.0
   date-released: "2025-01-17"
   license: MIT
-  repository-code: "https://github.com/DiogoRibeiro7/min-ratio-cycle"
+  repository-code: "https://github.com/DiogoRibeiro7/min_ratio_cycle"
   url: "https://min-ratio-cycle.readthedocs.io/"
+  doi: "10.5281/zenodo.17067890"
 
 references:
   - type: article
@@ -80,7 +84,7 @@ references:
       - type: arXiv
         value: "1704.08122"
     notes: "Theoretical foundation for the algorithms implemented in this software"
-    
+
   - type: article
     title: "Minimum-mean-weight cycles and minimum ratio spanning trees"
     authors:
@@ -92,7 +96,7 @@ references:
     pages: "201-209"
     publisher: "Academic Press"
     notes: "Original parametric search approach for ratio optimization problems"
-    
+
   - type: book
     title: "Introduction to Algorithms"
     authors:
@@ -145,24 +149,24 @@ contact:
 # Usage examples for different contexts
 citation-examples:
   academic-paper: >-
-    Ribeiro, D. (2025). min-ratio-cycle: Fast minimum cost-to-time ratio 
-    cycle detection (Version 0.1.0) [Computer software]. 
-    https://github.com/DiogoRibeiro7/min-ratio-cycle
-    
+    Ribeiro, D. (2025). min-ratio-cycle: Fast minimum cost-to-time ratio
+    cycle detection (Version 0.1.0) [Computer software].
+    https://github.com/DiogoRibeiro7/min_ratio_cycle
+
   bibtex: |
     @software{min_ratio_cycle,
       title = {min-ratio-cycle: Fast minimum cost-to-time ratio cycle detection},
       author = {Diogo de Bastos Ribeiro},
       year = {2025},
       version = {0.1.0},
-      url = {https://github.com/DiogoRibeiro7/min-ratio-cycle},
+      url = {https://github.com/DiogoRibeiro7/min_ratio_cycle},
       note = {Python package for efficient minimum ratio cycle detection}
     }
-    
+
   apa: >-
-    Ribeiro, D. de B. (2025). min-ratio-cycle: Fast minimum cost-to-time 
-    ratio cycle detection (Version 0.1.0) [Computer software]. GitHub. 
-    https://github.com/DiogoRibeiro7/min-ratio-cycle
+    Ribeiro, D. de B. (2025). min-ratio-cycle: Fast minimum cost-to-time
+    ratio cycle detection (Version 0.1.0) [Computer software]. GitHub.
+    https://github.com/DiogoRibeiro7/min_ratio_cycle
 
 # Additional metadata
 commit: "initial-release"
@@ -180,7 +184,7 @@ platforms:
 
 # Documentation and support
 documentation: "https://min-ratio-cycle.readthedocs.io/"
-issue-tracker: "https://github.com/DiogoRibeiro7/min-ratio-cycle/issues"
+issue-tracker: "https://github.com/DiogoRibeiro7/min_ratio_cycle/issues"
 repository-artifact: "https://pypi.org/project/min-ratio-cycle/"
 
 # Quality assurance information

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ If you use this software in academic work, please cite both the software and the
   author = {Diogo de Bastos Ribeiro},
   year = {2025},
   url = {https://github.com/DiogoRibeiro7/min-ratio-cycle},
-  doi = {10.5281/zenodo.PLACEHOLDER},
+  doi = {10.5281/zenodo.17067890},
   version = {0.1.0}
 }
 ```
@@ -324,7 +324,7 @@ If you use this software in academic work, please cite both the software and the
 ```
 
 **Quick Citation** (for informal references):
-> Ribeiro, D. (2025). min-ratio-cycle: Fast minimum cost-to-time ratio cycle detection (v0.1.0). *Journal of Open Source Software*. DOI: 10.5281/zenodo.PLACEHOLDER
+> Ribeiro, D. (2025). min-ratio-cycle: Fast minimum cost-to-time ratio cycle detection (v0.1.0). *Journal of Open Source Software*. DOI: 10.5281/zenodo.17067890
 
 ---
 


### PR DESCRIPTION
## Summary
- merge latest changes from develop into main
- includes Zenodo metadata and citation DOI updates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync main with develop, fixing citation metadata (adds Zenodo DOI and corrects repo URLs) and simplifying CI to run tests on Ubuntu only.

- **Bug Fixes**
  - Added DOI `10.5281/zenodo.17067890` and replaced placeholders in `README.md` and `CITATION.cff`.
  - Corrected repository links from `min-ratio-cycle` to `min_ratio_cycle`.
  - Cleaned up `.zenodo.json` (flattened `"license": "MIT"`, removed unused fields, fixed `isIdenticalTo` URL).

- **Refactors**
  - CI: test job now runs on `ubuntu-latest` only, keeping the Python `3.10–3.12` matrix.

<sup>Written for commit c5bef891233b0250c546d534e9d6eeae760bbc1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

