### PR TITLE
Add Dependabot, CODEOWNERS, and Zenodo metadata cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DiogoRibeiro7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "DiogoRibeiro7"
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "DiogoRibeiro7"
     open-pull-requests-limit: 10

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,59 +1,24 @@
 {
   "title": "min-ratio-cycle: Fast minimum cost-to-time ratio cycle detection in directed graphs",
-  "description": "A high-performance Python library for finding minimum cost-to-time ratio cycles in directed graphs. Features NumPy-accelerated algorithms with exact Stern-Brocot search for integer inputs, comprehensive validation, performance analytics, and visualization tools. Implements Lawler's parametric search with vectorized Bellman-Ford negative cycle detection for applications in finance, operations research, network engineering, and supply chain optimization.",
+  "description": "A high-performance Python library for finding minimum cost-to-time ratio cycles in directed graphs. Features NumPy-accelerated algorithms with exact Stern-Brocot search for integer inputs, comprehensive validation, performance analytics, and visualization tools.",
   "creators": [
     {
       "name": "Ribeiro, Diogo de Bastos",
-      "affiliation": "ESMAD – Instituto Politécnico do Porto",
+      "affiliation": "ESMAD - Instituto Politecnico do Porto",
       "orcid": "0009-0001-2022-7072"
     }
   ],
-  "contributors": [],
   "keywords": [
     "graph algorithms",
     "minimum ratio cycle",
-    "parametric search",
-    "Bellman-Ford algorithm",
-    "Stern-Brocot tree",
-    "operations research",
     "optimization",
-    "Python",
-    "NumPy",
-    "directed graphs",
-    "cycle detection",
-    "computational geometry",
-    "currency arbitrage",
-    "resource scheduling",
-    "network routing",
-    "supply chain optimization"
+    "python",
+    "operations research"
   ],
-  "access_right": "open",
   "license": "MIT",
   "upload_type": "software",
-  "publication_date": "2025-01-17",
-  "subjects": [
-    {
-      "term": "Computer Science",
-      "identifier": "https://id.loc.gov/authorities/subjects/sh85029552.html",
-      "scheme": "url"
-    },
-    {
-      "term": "Mathematics",
-      "identifier": "https://id.loc.gov/authorities/subjects/sh85082139.html",
-      "scheme": "url"
-    },
-    {
-      "term": "Operations Research",
-      "identifier": "https://id.loc.gov/authorities/subjects/sh85094935.html",
-      "scheme": "url"
-    }
-  ],
+  "access_right": "open",
   "related_identifiers": [
-    {
-      "relation": "isSupplementTo",
-      "identifier": "https://doi.org/10.4230/LIPIcs.ICALP.2017.124",
-      "resource_type": "publication-article"
-    },
     {
       "relation": "isDocumentedBy",
       "identifier": "https://min-ratio-cycle.readthedocs.io/",
@@ -66,38 +31,8 @@
     },
     {
       "relation": "isVersionOf",
-      "identifier": "https://pypi.org/project/min-ratio-cycle/",
+      "identifier": "https://doi.org/10.5281/zenodo.17067890",
       "resource_type": "software"
-    }
-  ],
-  "references": [
-    "Bringmann, K., Hansen, T. D., & Krinninger, S. (2017). Improved Algorithms for Computing the Cycle of Minimum Cost-to-Time Ratio in Directed Graphs. In 44th International Colloquium on Automata, Languages, and Programming (ICALP 2017). https://doi.org/10.4230/LIPIcs.ICALP.2017.124",
-    "Lawler, E. L. (1976). Minimum-mean-weight cycles and minimum ratio spanning trees. Combinatorial algorithms, 201-209. Academic Press.",
-    "Graham, R. L., Knuth, D. E., & Patashnik, O. (1994). Concrete mathematics: a foundation for computer science (2nd ed.). Addison-Wesley.",
-    "Harris, C. R., et al. (2020). Array programming with NumPy. Nature, 585(7825), 357-362. https://doi.org/10.1038/s41586-020-2649-2"
-  ],
-  "notes": "This software implements state-of-the-art algorithms for the minimum cost-to-time ratio cycle problem, providing both exact and approximate solutions with comprehensive validation and performance analytics. The library is designed for research and industrial applications in optimization, finance, and operations research.",
-  "grants": [],
-  "thesis_supervisors": [],
-  "thesis_university": "",
-  "imprint_publisher": "",
-  "imprint_isbn": "",
-  "partof_title": "",
-  "partof_pages": "",
-  "journal_title": "",
-  "journal_volume": "",
-  "journal_issue": "",
-  "journal_pages": "",
-  "conference_title": "",
-  "conference_acronym": "",
-  "conference_dates": "",
-  "conference_place": "",
-  "conference_url": "",
-  "conference_session": "",
-  "conference_session_part": "",
-  "communities": [
-    {
-      "identifier": "zenodo"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add .github/dependabot.yml for weekly pip and GitHub Actions updates
- add .github/CODEOWNERS with @DiogoRibeiro7 as code owner
- simplify .zenodo.json metadata for Zenodo compatibility
- configure Dependabot reviewers to @DiogoRibeiro7

## Validation
- pre-commit hooks pass on committed changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds weekly Dependabot updates for `pip` and `github-actions`, sets repo `CODEOWNERS` to `@DiogoRibeiro7`, and cleans up `.zenodo.json` for Zenodo compatibility.

- **Dependencies**
  - Added `.github/dependabot.yml` with weekly updates for `pip` and `github-actions`.
  - Dependabot requests reviews from `@DiogoRibeiro7` (limit 10 open PRs).

- **Refactors**
  - Simplified `.zenodo.json`: trimmed description/keywords, normalized affiliation, and set `isVersionOf` to the Zenodo DOI.

<sup>Written for commit e6f9914a3addc9672e8c6aac800d1d9fa98b5daf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

