### PR TITLE
Docs: visual refresh for Read the Docs

### DIFF
--- a/docs/source/_static/brand.css
+++ b/docs/source/_static/brand.css
@@ -1,0 +1,57 @@
+/* Brand-forward polish for the docs without changing content structure. */
+
+.content .toctree-wrapper > p.caption {
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-brand-content);
+}
+
+/* Landing page hero strip */
+.document h1 {
+  position: relative;
+  margin-bottom: 1.2rem;
+  padding: 1.15rem 1.25rem;
+  border-radius: 14px;
+  background:
+    radial-gradient(circle at 15% 15%, rgba(94, 234, 212, 0.28), transparent 45%),
+    radial-gradient(circle at 85% 20%, rgba(103, 232, 249, 0.24), transparent 40%),
+    linear-gradient(120deg, rgba(15, 118, 110, 0.12), rgba(11, 114, 133, 0.07));
+  border: 1px solid rgba(11, 114, 133, 0.25);
+}
+
+/* Card-like nav links on index */
+.toctree-wrapper.compound li > a.reference.internal {
+  display: block;
+  margin: 0.4rem 0;
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--color-background-secondary) 86%, white 14%);
+  border: 1px solid color-mix(in srgb, var(--color-brand-content) 20%, transparent);
+  transition: transform 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.toctree-wrapper.compound li > a.reference.internal:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--color-brand-primary) 42%, transparent);
+  box-shadow: 0 6px 14px rgba(15, 118, 110, 0.12);
+}
+
+/* Better callouts and code framing */
+.admonition {
+  border-radius: 12px;
+  border-width: 1px;
+}
+
+div.highlight {
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--color-brand-content) 30%, transparent);
+  overflow: hidden;
+}
+
+/* Slightly stronger active state in sidebar */
+.sidebar-tree .current > a,
+.sidebar-tree .current-page > a {
+  font-weight: 700;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,3 +22,38 @@ exclude_patterns = []
 
 html_theme = "furo"
 html_static_path = ["_static"]
+html_css_files = ["brand.css"]
+
+html_theme_options = {
+    "top_of_page_button": "edit",
+    "source_repository": "https://github.com/DiogoRibeiro7/min_ratio_cycle/",
+    "source_branch": "develop",
+    "source_directory": "docs/source/",
+    "light_css_variables": {
+        "color-brand-primary": "#0f766e",
+        "color-brand-content": "#0b7285",
+        "color-foreground-primary": "#102a43",
+        "color-foreground-secondary": "#334e68",
+        "color-background-primary": "#f8fbff",
+        "color-background-secondary": "#eef6ff",
+        "color-sidebar-background": "#e8f4ff",
+        "color-sidebar-item-background--hover": "#d8ebff",
+        "color-sidebar-link-text--top-level": "#0b3c5d",
+        "color-link": "#0b7285",
+        "color-link--hover": "#0f766e",
+        "color-admonition-background": "#effaff",
+    },
+    "dark_css_variables": {
+        "color-brand-primary": "#5eead4",
+        "color-brand-content": "#67e8f9",
+        "color-foreground-primary": "#dbeafe",
+        "color-foreground-secondary": "#bfdbfe",
+        "color-background-primary": "#0b1220",
+        "color-background-secondary": "#111b2e",
+        "color-sidebar-background": "#0e172a",
+        "color-sidebar-item-background--hover": "#13213a",
+        "color-link": "#67e8f9",
+        "color-link--hover": "#5eead4",
+        "color-admonition-background": "#0f2238",
+    },
+}


### PR DESCRIPTION
## Summary
- add branded Furo theme options in Sphinx config
- add custom CSS for stronger visual hierarchy and color
- improve docs visual appeal without changing content structure

## Files
- docs/source/conf.py
- docs/source/_static/brand.css

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the Read the Docs look with branded `furo` theme settings and a small custom stylesheet to improve hierarchy and readability. Styling only; no content changes.

- **New Features**
  - Set `furo` `html_theme_options` with brand colors for light and dark, repo links, and an Edit button.
  - Add `brand.css` to style H1 hero, toctree link cards, callouts, code blocks, and sidebar active state.

<sup>Written for commit 9ef43aad8da3b69a05652af80aa9d7bc8728bd4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

