### PR TITLE
Docs: improve Read the Docs typography

### DIFF
--- a/docs/source/_static/brand.css
+++ b/docs/source/_static/brand.css
@@ -1,4 +1,19 @@
 /* Brand-forward polish for the docs without changing content structure. */
+@import url("https://fonts.googleapis.com/css2?family=Merriweather:wght@700;800&family=Source+Sans+3:wght@400;500;600;700&display=swap");
+
+body {
+  font-family: "Source Sans 3", "Segoe UI", "Helvetica Neue", sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Merriweather", Georgia, "Times New Roman", serif;
+  letter-spacing: 0.01em;
+}
 
 .content .toctree-wrapper > p.caption {
   font-size: 0.82rem;


### PR DESCRIPTION
## Summary
- update RTD typography in custom docs CSS
- use Source Sans 3 for body text and Merriweather for headings
- improve visual readability and personality

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes Read the Docs typography for better readability and a more polished look. Body text now uses Source Sans 3; headings use Merriweather with slight letter-spacing.

Loads the fonts via Google Fonts and updates the custom docs CSS to apply them.

<sup>Written for commit 9622ebc3779df4241032b09ad5d382878aa88973. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

