### PR TITLE
Docs: update RTD title and branding

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,11 +1,16 @@
 import os
 import sys
+from importlib import metadata
 
 sys.path.insert(0, os.path.abspath("../.."))
 
-project = "Min Ratio Cycle"
+project = "min-ratio-cycle"
 author = "Diogo Ribeiro"
-release = "0.1.0"
+try:
+    release = metadata.version("min-ratio-cycle")
+except metadata.PackageNotFoundError:
+    release = "dev"
+version = release
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -21,6 +26,7 @@ templates_path = ["_templates"]
 exclude_patterns = []
 
 html_theme = "furo"
+html_title = "min-ratio-cycle documentation"
 html_static_path = ["_static"]
 html_css_files = ["brand.css"]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
-Welcome to Min Ratio Cycle's documentation!
-===========================================
+Welcome to min-ratio-cycle documentation
+========================================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Summary
- set docs project name to min-ratio-cycle
- set explicit HTML title without pinned version text
- update index page title copy to match branding

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align docs branding to `min-ratio-cycle` on Read the Docs and set an explicit HTML title without pinned version text. Sphinx now reads the package version from `min-ratio-cycle` (fallback to `dev`) and the index page title matches the new branding.

<sup>Written for commit 36a0f8911498de32a7405c85c515f4df82c8b24e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

